### PR TITLE
ci: push image to ghcr

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,9 +1,6 @@
 name: Build Wyoming Piper GLaDOS Image
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
@@ -35,3 +32,5 @@ jobs:
           tags: |
             ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/${{ env.DOCKER_IMAGE_NAME }}:latest
             ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
On merge to master, we push the image to ghcr. Our build step now caches
the image layers so that we can retrieve them during future builds, but
we'll rebuild the image in the push step, so we only want to trigger
that one.