### PR TITLE
fix: don't download other voices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ WORKDIR /app
 COPY en_US-glados-medium.onnx /app/voices/en_US-glados-medium.onnx
 COPY en_US-glados-medium.onnx.json /app/voices/en_US-glados-medium.onnx.json
 
-CMD ["--voice", "en_US-glados-medium"]
+CMD ["--data-dir", "/app/voices", "--download-dir", "/app/voices", "--voice", "en_US-glados-medium"]


### PR DESCRIPTION
By default, the image downloads the set of default voices. We want to speed up start times and avoid unncessary data tranfer, so we'll disable this behavior by resetting the data dir to the directory that contains our GLadOS voice only.