### PR TITLE
ci: allow build workflow to push image

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
In our push workflow, we must request `packages: write` permission explicitly in order for the workflow to be allowed to push a package.

The value evaluated at runtime is an intersection of the caller and the callees' permissions; therefore, when the PR workflow runs, it will not have permission to write, as the caller does not have permission.