### PR TITLE
ci: Add version to differentiate builds

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -8,6 +8,10 @@ on:
         description: 'Base version of Wyoming Piper image to use'
         required: true
         type: string
+      run_number:
+        description: 'GitHub run number for tagging the image'
+        required: true
+        type: number
       push_image:
         description: 'Whether to push the built image to the registry'
         required: false
@@ -17,7 +21,7 @@ on:
 env:
   IMAGE_NAME: wyoming-piper-glados
   DOCKER_REGISTRY: ghcr.io
-  IMAGE_VERSION: ${{ inputs.base_piper_version }}
+  IMAGE_VERSION: ${{ inputs.base_piper_version }}+${{ inputs.run_number }}
 
 jobs:
   build:

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -19,4 +19,5 @@ jobs:
     uses: ./.github/workflows/build-image.yaml
     with:
       base_piper_version: '1.6.2'
+      run_number: ${{ github.run_number }}
       push_image: true

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,3 +18,4 @@ jobs:
     uses: ./.github/workflows/build-image.yaml
     with:
       base_piper_version: '1.6.2'
+      run_number: ${{ github.run_number }}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 GLaDOS Voice Running in Wyoming Piper
 
 Inspiration taken from [Adam Conway](https://www.xda-developers.com/glados-controls-smart-home-home-assistant/). Image based on [rhasspp/wyoming-piper](https://github.com/rhasspy/wyoming-piper), packaged with voice from [GLaDOS Personality Core](https://github.com/dnhkng/GLaDOS).
+
+## Versioning
+
+The major, minor, and patch versions of this image will be identical to the underlying rhasspp/wyoming-piper version. An ever increasing run number will be appended to differentiate new builds on the same version of Piper.


### PR DESCRIPTION
We need a way to differentiate different versions of this image built on a single base piper image. We stay with using the base image's versio for major/minor/patch, but we append build metadata to indicate when we've rebuilt our image.