### PR TITLE
ci: define run_number as string

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -11,7 +11,7 @@ on:
       run_number:
         description: 'GitHub run number for tagging the image'
         required: true
-        type: number
+        type: string
       push_image:
         description: 'Whether to push the built image to the registry'
         required: false

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -21,7 +21,7 @@ on:
 env:
   IMAGE_NAME: wyoming-piper-glados
   DOCKER_REGISTRY: ghcr.io
-  IMAGE_VERSION: ${{ inputs.base_piper_version }}+${{ inputs.run_number }}
+  IMAGE_VERSION: ${{ inputs.base_piper_version }}-${{ inputs.run_number }}
 
 jobs:
   build:

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -15,7 +15,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    needs: lint
     uses: ./.github/workflows/build-image.yaml
     with:
       base_piper_version: '1.6.2'

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -14,7 +14,6 @@ jobs:
   build:
     permissions:
       contents: read
-    needs: lint
     uses: ./.github/workflows/build-image.yaml
     with:
       base_piper_version: '1.6.2'


### PR DESCRIPTION
This github variable is a string, not a number, which works in our favor anyway as we're concatenating it to the version.