### PR TITLE
ci: allow packages write in build-image workflow

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -14,6 +14,7 @@ jobs:
   build:
     permissions:
       contents: read
+      packages: write
     uses: ./.github/workflows/build-image.yaml
     with:
       base_piper_version: '1.6.2'


### PR DESCRIPTION
In order to publish the image, we need to allow the called workflow to publish the package. This could allow anyone to push packages to our repository, but we'll require organization approval before running any github actions from external users.