### PR TITLE
fix: update dataset in onnx

### DIFF
--- a/en_US-glados-medium.onnx.json
+++ b/en_US-glados-medium.onnx.json
@@ -1,8 +1,8 @@
 {
-    "dataset": "glados",
+    "dataset": "en_US-glados-medium",
     "audio": {
         "sample_rate": 22050,
-        "quality": "stacked_llama"
+        "quality": "medium"
     },
     "espeak": {
         "voice": "en-us"


### PR DESCRIPTION
In order for the right voice to be advertised and picked up by Home Assistant, we need to edit the glados metadata. If we don't, piper advertises "glados" under American English, and then can't find the voice when HA requests it.