### PR TITLE
ci: build and publish on main

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -17,6 +17,7 @@ on:
 env:
   IMAGE_NAME: wyoming-piper-glados
   DOCKER_REGISTRY: ghcr.io
+  IMAGE_REF: ghcr.io/${{ github.repository_owner }}/wyoming-piper-glados
 
 jobs:
   build:
@@ -56,7 +57,7 @@ jobs:
           file: ./Dockerfile
           push: ${{ inputs.push_image }}
           tags: |
-            ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.piper-version.outputs.version }}-${{ inputs.run_number }}
+            ${{ env.IMAGE_REF }}:latest
+            ${{ env.IMAGE_REF }}:${{ steps.piper-version.outputs.version }}-${{ inputs.run_number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -4,7 +4,7 @@ name: Pull Request
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   lint:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -4,7 +4,7 @@ name: Pull Request
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   lint:


### PR DESCRIPTION
We renamed the default branch, so need to update the build and publish actions accordingly - otherwise, we don't get automated builds anymore.