### PR TITLE
ci: use . instead of - for build metadata

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -58,6 +58,6 @@ jobs:
           push: ${{ inputs.push_image }}
           tags: |
             ${{ env.IMAGE_REF }}:latest
-            ${{ env.IMAGE_REF }}:${{ steps.piper-version.outputs.version }}-${{ inputs.run_number }}
+            ${{ env.IMAGE_REF }}:${{ steps.piper-version.outputs.version }}.${{ inputs.run_number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
If we use a - in the image name, instead of a ., certain semver parsers will see this as a pre-release. We change to . (as + is not valid in a docker tag) to ensure that the stable versions are seen as that.